### PR TITLE
Correct URL

### DIFF
--- a/bugs/695096.html
+++ b/bugs/695096.html
@@ -5,6 +5,6 @@ var element = document.createElement('audio');
 element.onerror = function() {
   window.location = window.location;
 };
-element.src = '.?' + new Date().getTime();
+element.src = window.location.href + '?' + new Date().getTime();
 }());
 </script>


### PR DESCRIPTION
Hi @mounirlamouri! The script I shared in my issue report made an invalid
assumption: that the server would respond to requests for the document's
directory (i.e. `.`) with an HTTP 2xx status code. The webserver I have been
using for local testing behaves in this way (providing a directory listing),
but the server implemented by GitHub on github.io does not.

This patch corrects the test script issue and should expose the reported
Chromium bug:

![foo](https://cloud.githubusercontent.com/assets/677252/24474542/ef91713e-149a-11e7-92b1-bdcc80d5a9cc.gif)