### PR TITLE
Replace missing '>' in audio tag

### DIFF
--- a/media/dynamic-controls.html
+++ b/media/dynamic-controls.html
@@ -17,7 +17,7 @@
     <track kind=subtitles src=test-sub-en.vtt srclang=en label=English>
     <track kind=subtitles src=test-sub-fr.vtt srclang=fr label=French>
   </video>
-  <audio src=BigBuck.webm controls width=400 style='display: none;' loop</audio>
+  <audio src=BigBuck.webm controls width=400 style='display: none;' loop></audio>
   <fieldset>
     <legend>Options</legend>
     <div><label>Video <input type=radio name=mediatype value=video checked></label> <label>Audio <input type=radio name=mediatype value=audio></label></div>


### PR DESCRIPTION
Heya Mounir!

Hope you're doing well.  There's a missing '>' in an audio tag for one of the test files that, it turns out, is important.  Luckily, I have a few spares.

thanks
-fl